### PR TITLE
chore: update to shorebird dev and flutter stable

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.0"
   fake_async:
     dependency: transitive
     description:
@@ -71,10 +71,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
@@ -87,10 +87,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.14"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
@@ -103,18 +103,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -164,10 +164,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
@@ -177,4 +177,4 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.19.4 <4.0.0"
+  dart: ">=2.19.4 <3.0.0"

--- a/shorebird.yaml
+++ b/shorebird.yaml
@@ -1,1 +1,6 @@
+# This file is used to configure the Shorebird CLI.
+# Learn more at https://shorebird.dev
+
+# This is the unique identifier for your app.
 app_id: time_shift
+base_url: https://api-dev.shorebird.dev


### PR DESCRIPTION
- update to Flutter stable channel
- update to use the shorebird dev env

@eseidel as we discussed, this version is currently incompatible but isn't failing gracefully

Logs:

```
I/flutter (11151): [INFO:flutter_main.cc(108)] Starting Shorebird update
W/flutter (11151): updater::cache: Failed to load updater state: No such file or directory (os error 2)
I/flutter (11151): updater::network: Sending patch check request: PatchCheckRequest { app_id: "time_shift", channel: "stable", release_version: "1.0.0", patch_number: None, platform: "android", arch: "aarch64" }
D/flutter (11151): reqwest::connect: starting new connection: https://api-dev.shorebird.dev/
D/flutter (11151): rustls::client::hs: No cached session for DnsName(DnsName(DnsName("api-dev.shorebird.dev")))
D/flutter (11151): rustls::client::hs: Not resuming any session
D/flutter (11151): rustls::client::hs: Using ciphersuite TLS13_AES_256_GCM_SHA384
D/flutter (11151): rustls::client::tls13: Not resuming
D/flutter (11151): rustls::client::tls13: TLS1.3 encrypted extensions: [Protocols([6832])]
D/flutter (11151): rustls::client::hs: ALPN protocol is Some(b"h2")
I/flutter (11151): updater::network: Patch check response: PatchCheckResponse { patch_available: true, patch: Some(Patch { number: 3, hash: "#", download_url: "https://storage.googleapis.com/patch_artifacts/6fb9c8ba-5fb8-45e4-a45d-ce572938e94e/dlc.vmcode" }) }
D/flutter (11151): reqwest::connect: starting new connection: https://storage.googleapis.com/
D/flutter (11151): rustls::client::hs: No cached session for DnsName(DnsName(DnsName("storage.googleapis.com")))
D/flutter (11151): rustls::client::hs: Not resuming any session
D/flutter (11151): rustls::client::hs: Using ciphersuite TLS13_AES_256_GCM_SHA384
D/flutter (11151): rustls::client::tls13: Not resuming
D/flutter (11151): rustls::client::tls13: TLS1.3 encrypted extensions: [Protocols([6832])]
D/flutter (11151): rustls::client::hs: ALPN protocol is Some(b"h2")
D/flutter (11151): rustls::client::tls13: Ticket saved
D/flutter (11151): rustls::client::tls13: Ticket saved
I/flutter (11151): [INFO:flutter_main.cc(115)] Active path: /data/user/0/dev.shorebird.u_shorebird_clock/code_cache/shorebird_updater/slot_0/dlc.vmcode
I/flutter (11151): [INFO:flutter_main.cc(124)] Active version: 3
E/flutter (11151): [ERROR:flutter/runtime/dart_vm_data.cc(20)] VM snapshot invalid and could not be inferred from settings.
E/flutter (11151): [ERROR:flutter/runtime/dart_vm.cc(268)] Could not set up VM data to bootstrap the VM from.
E/flutter (11151): [ERROR:flutter/runtime/dart_vm_lifecycle.cc(85)] Could not create Dart VM instance.
F/flutter (11151): [FATAL:flutter/shell/common/shell.cc(141)] Check failed: vm. Must be able to initialize the VM.
```