### PR TITLE
Add ability to choose clock face from command line

### DIFF
--- a/lib/clocks/clock_face.dart
+++ b/lib/clocks/clock_face.dart
@@ -2,17 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:time_shift/clocks/generative_clock/generative_clock.dart';
 import 'package:time_shift/clocks/particle_clock/particle_clock.dart';
 
-enum Clock {
+/// All available clock faces.
+enum ClockFace {
   generative,
   particle,
 }
 
-extension ClockWidget on Clock {
+extension ClockFaceWidget on ClockFace {
+  /// Builds the clock face widget associated with this [ClockFace].
   Widget get widget {
     switch (this) {
-      case Clock.generative:
+      case ClockFace.generative:
         return const GenerativeClock();
-      case Clock.particle:
+      case ClockFace.particle:
         return const ParticleClock();
     }
   }

--- a/lib/clocks/clocks.dart
+++ b/lib/clocks/clocks.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:time_shift/clocks/generative_clock/generative_clock.dart';
+import 'package:time_shift/clocks/particle_clock/particle_clock.dart';
+
+enum Clock {
+  generative,
+  particle,
+}
+
+extension ClockWidget on Clock {
+  Widget get widget {
+    switch (this) {
+      case Clock.generative:
+        return const GenerativeClock();
+      case Clock.particle:
+        return const ParticleClock();
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,22 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'clocks/clocks.dart';
+import 'clocks/clock_face.dart';
 
-/// Use this argument to choose a clock face. Defaults to particle.
+/// Use this argument to choose a clock face. Defaults to particle if value is
+/// provided or if the value provided is unrecognized.
 ///
 /// Example:
-/// `shorebird run -- --dart-define clock=generative`
-const clockArgName = 'clock';
+/// `shorebird run -- --dart-define clock_face=generative`
+const clockFaceArgName = 'clock_face';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
 
-  const clockName = String.fromEnvironment(clockArgName);
-  final clock = Clock.values.firstWhere(
+  const clockName = String.fromEnvironment(clockFaceArgName);
+  final clock = ClockFace.values.firstWhere(
     (clock) => clock.name == clockName,
-    orElse: () => Clock.particle,
+    orElse: () => ClockFace.particle,
   );
 
   runApp(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:time_shift/clocks/particle_clock/particle_clock.dart';
+
+import 'clocks/clocks.dart';
+
+/// Use this argument to choose a clock face. Defaults to particle.
+///
+/// Example:
+/// `shorebird run -- --dart-define clock=generative`
+const clockArgName = 'clock';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+
+  const clockName = String.fromEnvironment(clockArgName);
+  final clock = Clock.values.firstWhere(
+    (clock) => clock.name == clockName,
+    orElse: () => Clock.particle,
+  );
+
   runApp(
-    const MaterialApp(
-      home: ParticleClock(),
+    MaterialApp(
+      home: clock.widget,
     ),
   );
 }


### PR DESCRIPTION
Adds a command line argument to choose which clock face is used. Currently supported values are `particle` and `generative`.

To use:
`shorebird run -- --dart-define clock_face=generative`