### PR TITLE
Initial draft of publish_patch Github workflow to upload new versions of TimeShift on an hourly schedule

### DIFF
--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Shorebird
-        uses: shorebirdtech/setup-shorebird@v1.1
+        uses: https://github.com/shorebirdtech/setup-shorebird@v1
 
       - name: Setup Shorebird Credentials
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Setup Java
         uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Git Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -17,10 +17,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Shorebird
-        uses: https://github.com/shorebirdtech/setup-shorebird@v1
+        id: install-shorebird
+        uses: shorebirdtech/setup-shorebird@v1
 
       - name: Setup Shorebird Credentials
         run: |
+          echo ${{ steps.install-shorebird.outputs.INSTALL_PATH }} >> $GITHUB_PATH
           mkdir -p $XDG_CONFIG_HOME/shorebird
           echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "$XDG_CONFIG_HOME/shorebird/shorebird-session.json"
 

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -50,6 +50,7 @@ jobs:
           echo "Using clock face $clock_face"
           echo "clock_face=$clock_face" >> $GITHUB_ENV
 
+
       - name: Create Patch
         run: |
           echo "Creating patch with ${{ env.clock_face }} clock face"

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -21,8 +21,12 @@ jobs:
         run: |
           echo "SHOREBIRD_CREDENTIALS_PATH is $SHOREBIRD_CREDENTIALS_PATH"
           mkdir -p $SHOREBIRD_CREDENTIALS_PATH
+          echo "touching $SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json"
           touch $SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json
-          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "$SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json"
+          echo "touched $SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json"
+          echo "writing secrets to json file"
+          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > $SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json
+          echo "wrote secrets to json file"
 
       - name: Git Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -19,12 +19,8 @@ jobs:
     steps:
       - name: Setup Shorebird Credentials
         run: |
-          echo "SHOREBIRD_CREDENTIALS_PATH is $SHOREBIRD_CREDENTIALS_PATH"
           mkdir -p "$SHOREBIRD_CREDENTIALS_PATH"
-          echo "touching ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
-          touch "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
-          echo "touched ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
-          echo "writing secrets to json file"
+          echo "writing secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo "wrote secrets to json file"
 

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -16,7 +16,6 @@ jobs:
         # Choose a clock face based on the current hour
         # Even hours = particle
         # Odd hours = generative
-
         current_hour=$(date +%H)
         if [ $(($current_hour % 2)) -eq "0" ]; then
           clock_face=particle

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  # Note: this is specific to macOS
+  # Note: this is specific to macOS - this will be a different value for Linux
   SHOREBIRD_CREDENTIALS_PATH: ~/Library/Application\ Support/shorebird
 
 jobs:

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -5,7 +5,7 @@ name: Publish Patch
 on:
   schedule:
     - cron: '*/15 */1 * * *'
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   publish_patch:

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -1,0 +1,29 @@
+name: Publish Patch
+
+# Run 15 minutes after the hour, every hour.
+# We use this instead of the top of the hour to avoid heavy-traffic times on github.
+on:
+  schedule:
+    - cron: '*/15 */1 * * *'
+
+jobs:
+  publish_patch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Choose Clock Face
+      - run: |
+        # Choose a clock face based on the current hour
+        # Even hours = particle
+        # Odd hours = generative
+
+        current_hour=$(date +%H)
+        if [ $(($current_hour % 2)) -eq "0" ]; then
+          clock_face=particle
+        else
+          clock_face=generative
+        fi
+
+      - name: Build Patch
+      - run: shorebird patch -- --dart-define clock_face=$clock_face
+        

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Note: this is specific to macOS
-  SHOREBIRD_CREDENTIALS_PATH: $HOME/Library/Application\ Support/shorebird
+  SHOREBIRD_CREDENTIALS_PATH: ~/Library/Application\ Support/shorebird
 
 jobs:
   publish_patch:

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -11,14 +11,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.7.8
+          channel: stable
 
       - name: Install Shorebird
         run: curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | sh
-
-      - name: Git Checkout
-        uses: actions/checkout@v3
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -8,6 +8,10 @@ on:
   workflow_dispatch:
   pull_request:
 
+env:
+  # Note: this is specific to macOS
+  SHOREBIRD_CREDENTIALS_PATH: $HOME/Library/Application Support/shorebird
+
 jobs:
   publish_patch:
     runs-on: macos-latest
@@ -21,8 +25,8 @@ jobs:
 
       - name: Setup Shorebird Credentials
         run: |
-          mkdir -p $XDG_CONFIG_HOME/shorebird
-          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "$XDG_CONFIG_HOME/shorebird/shorebird-session.json"
+          mkdir -p $SHOREBIRD_CREDENTIALS_PATH
+          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "$SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json"
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Note: this is specific to macOS
-  SHOREBIRD_CREDENTIALS_PATH: ~/Library/Application Support/shorebird
+  SHOREBIRD_CREDENTIALS_PATH: $HOME/Library/Application Support/shorebird
 
 jobs:
   publish_patch:
@@ -20,7 +20,9 @@ jobs:
       - name: Setup Shorebird Credentials
         run: |
           echo "HOME is $HOME"
+          echo "SHOREBIRD_CREDENTIALS_PATH is $SHOREBIRD_CREDENTIALS_PATH"
           mkdir -p $SHOREBIRD_CREDENTIALS_PATH
+          touch $SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json
           echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "$SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json"
 
       - name: Git Checkout

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -27,9 +27,7 @@ jobs:
         run: |
           mkdir -p "$SHOREBIRD_CREDENTIALS_PATH"
           echo "writing secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
-          # echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
-          echo 'asdfasdf' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
-          cat "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
+          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo "wrote secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
 
       - name: Choose Clock Face

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -8,9 +8,17 @@ on:
 
 jobs:
   publish_patch:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install Shorebird
+        run: curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | sh
+
+      - name: Git Checkout
+        uses: actions/checkout@v3
+
       - name: Choose Clock Face
         run: |
           # Choose a clock face based on the current hour
@@ -22,7 +30,10 @@ jobs:
           else
             clock_face=generative
           fi
+          echo $clock_face >> $GITHUB_ENV
 
-      - name: Build Patch
-        run: shorebird patch -- --dart-define clock_face=$clock_face
+      - name: Create Patch
+        run: |
+          echo "Creating patch with ${{ env.clock_face }}"
+          shorebird patch -- --dart-define clock_face=${{ env.clock_face }}
         

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -4,13 +4,9 @@ name: Publish Patch
 # We use this instead of the top of the hour to avoid heavy-traffic times on github.
 on:
   schedule:
-    - cron: '*/15 */1 * * *'
+    - cron: "*/15 */1 * * *"
   workflow_dispatch:
   pull_request:
-
-env:
-  # Note: this is specific to macOS - this will be a different value for Linux
-  SHOREBIRD_CREDENTIALS_PATH: ~/Library/Application\ Support/shorebird
 
 jobs:
   publish_patch:
@@ -25,6 +21,7 @@ jobs:
 
       - name: Setup Shorebird Credentials
         run: |
+          SHOREBIRD_CREDENTIALS_PATH=$HOME/Library/Application\ Support/shorebird
           mkdir -p "$SHOREBIRD_CREDENTIALS_PATH"
           echo "writing secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           # echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
@@ -51,4 +48,3 @@ jobs:
         run: |
           echo "Creating patch with ${{ env.clock_face }} clock face"
           shorebird patch -- --dart-define clock_face=${{ env.clock_face }}
-        

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Shorebird
-        uses: shorebirdtech/setup-shorebird@ed2912738a676459612aad64c63707b57b9dab64
+        uses: shorebirdtech/setup-shorebird@b965752a6418b35ab062730a5611b2b5f98920ab
 
       - name: Setup Shorebird Credentials
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -13,15 +13,15 @@ jobs:
     steps:
       - name: Choose Clock Face
       - run: |
-        # Choose a clock face based on the current hour
-        # Even hours = particle
-        # Odd hours = generative
-        current_hour=$(date +%H)
-        if [ $(($current_hour % 2)) -eq "0" ]; then
-          clock_face=particle
-        else
-          clock_face=generative
-        fi
+          # Choose a clock face based on the current hour
+          # Even hours = particle
+          # Odd hours = generative
+          current_hour=$(date +%H)
+          if [ $(($current_hour % 2)) -eq "0" ]; then
+            clock_face=particle
+          else
+            clock_face=generative
+          fi
 
       - name: Build Patch
       - run: shorebird patch -- --dart-define clock_face=$clock_face

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -17,6 +17,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Test XDG_CONFIG_HOME
+        run: echo "XDG_CONFIG_HOME is $XDG_CONFIG_HOME"
+
       - name: Git Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -5,6 +5,7 @@ name: Publish Patch
 on:
   schedule:
     - cron: '*/15 */1 * * *'
+  workflow_dispatch
 
 jobs:
   publish_patch:

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -21,11 +21,11 @@ jobs:
         run: |
           echo "SHOREBIRD_CREDENTIALS_PATH is $SHOREBIRD_CREDENTIALS_PATH"
           mkdir -p $SHOREBIRD_CREDENTIALS_PATH
-          echo "touching $SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json"
-          touch $SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json
-          echo "touched $SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json"
+          echo "touching ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
+          touch "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
+          echo "touched ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo "writing secrets to json file"
-          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > $SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json
+          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo "wrote secrets to json file"
 
       - name: Git Checkout

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -21,7 +21,7 @@ jobs:
 
       # TODO: move this to setup-shorebird once we've confirmed it works
       - name: Update PATH
-        run: export PATH="/home/runner/.config/shorebird/bin:$PATH"
+        run: echo "PATH=\"/home/runner/.config/shorebird/bin:$PATH\"" >> $"GITHUB_PATH"
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   publish_patch:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3
 
       - name: Install Shorebird
-        uses: shorebirdtech/setup-shorebird@d950431250c82de7a37f2748c63643e23994c48b
+        uses: shorebirdtech/setup-shorebird@70b705f05278f4af11ea6456d45b5a75d7e1c9a6
 
       - name: Setup Shorebird Credentials
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -17,9 +17,6 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - name: Test XDG_CONFIG_HOME
-        run: echo "XDG_CONFIG_HOME is $XDG_CONFIG_HOME"
-
       - name: Git Checkout
         uses: actions/checkout@v3
 
@@ -31,7 +28,7 @@ jobs:
           mkdir -p "$SHOREBIRD_CREDENTIALS_PATH"
           echo "writing secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           # echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
-          echo "{"api_key":"asdfadsfadsfads"}" > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
+          echo "{\"api_key\": \"asdfadsfadsfads\"}" > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo "wrote secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo "secret contents:"
           cat "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -10,23 +10,24 @@ on:
 
 env:
   # Note: this is specific to macOS
-  SHOREBIRD_CREDENTIALS_PATH: ${HOME}/Library/Application Support/shorebird
+  SHOREBIRD_CREDENTIALS_PATH: ~/Library/Application Support/shorebird
 
 jobs:
   publish_patch:
     runs-on: macos-latest
 
     steps:
+      - name: Setup Shorebird Credentials
+        run: |
+          echo $SHOREBIRD_CREDENTIALS_PATH
+          mkdir -p $SHOREBIRD_CREDENTIALS_PATH
+          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "$SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json"
+
       - name: Git Checkout
         uses: actions/checkout@v3
 
       - name: Install Shorebird
         uses: shorebirdtech/setup-shorebird@70b705f05278f4af11ea6456d45b5a75d7e1c9a6
-
-      - name: Setup Shorebird Credentials
-        run: |
-          mkdir -p $SHOREBIRD_CREDENTIALS_PATH
-          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "$SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json"
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -13,6 +13,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Setup Java
+        uses: actions/setup-java@v3
+
       - name: Git Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Shorebird Credentials
         run: |
           echo "SHOREBIRD_CREDENTIALS_PATH is $SHOREBIRD_CREDENTIALS_PATH"
-          mkdir -p $SHOREBIRD_CREDENTIALS_PATH
+          mkdir -p "$SHOREBIRD_CREDENTIALS_PATH'
           echo "touching ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           touch "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo "touched ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -8,11 +8,17 @@ on:
 
 jobs:
   publish_patch:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
-
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{inputs.flutter_version}}
+          channel: ${{inputs.flutter_channel}}
+          cache: true
+          cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
+
       - name: Install Shorebird
         run: curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | sh
 

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Shorebird
-        id: install-shorebird
         uses: shorebirdtech/setup-shorebird@v1
 
       - name: Setup Shorebird Credentials

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Note: this is specific to macOS
-  SHOREBIRD_CREDENTIALS_PATH: $HOME/Library/Application Support/shorebird
+  SHOREBIRD_CREDENTIALS_PATH: "${HOME}/Library/Application Support/shorebird"
 
 jobs:
   publish_patch:

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -21,7 +21,7 @@ jobs:
 
       # TODO: move this to setup-shorebird once we've confirmed it works
       - name: Update PATH
-        run: echo "/home/runner/.config/shorebird/bin" >> $"GITHUB_PATH"
+        run: echo "/home/runner/.config/shorebird/bin" >> $GITHUB_PATH
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Shorebird
-        uses: shorebirdtech/setup-shorebird@b965752a6418b35ab062730a5611b2b5f98920ab
+        uses: shorebirdtech/setup-shorebird@d950431250c82de7a37f2748c63643e23994c48b
 
       - name: Setup Shorebird Credentials
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: '*/15 */1 * * *'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   publish_patch:
@@ -18,8 +19,8 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.7.8
           channel: stable
+          flutter-version: 3.7.8
 
       - name: Install Shorebird
         run: curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | sh

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -19,9 +19,6 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - name: Install Rosetta
-        run: softwareupdate --install-rosetta --agree-to-license
-
       - name: Git Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Note: this is specific to macOS
-  SHOREBIRD_CREDENTIALS_PATH: "${HOME}/Library/Application Support/shorebird"
+  SHOREBIRD_CREDENTIALS_PATH: ${HOME}/Library/Application Support/shorebird
 
 jobs:
   publish_patch:

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -13,11 +13,6 @@ jobs:
     steps:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{inputs.flutter_version}}
-          channel: ${{inputs.flutter_channel}}
-          cache: true
-          cache-key: flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}
 
       - name: Install Shorebird
         run: curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | sh

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -36,7 +36,7 @@ jobs:
           else
             clock_face=generative
           fi
-          echo $clock_face >> $GITHUB_ENV
+          echo "clock_face=$clock_face" >> $GITHUB_ENV
 
       - name: Create Patch
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Setup Shorebird Credentials
         run: |
-          echo $SHOREBIRD_CREDENTIALS_PATH
+          echo "HOME is $HOME"
           mkdir -p $SHOREBIRD_CREDENTIALS_PATH
           echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "$SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json"
 

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -19,6 +19,10 @@ jobs:
       - name: Install Shorebird
         uses: shorebirdtech/setup-shorebird@v1
 
+      # TODO: move this to setup-shorebird once we've confirmed it works
+      - name: Update PATH
+        run: export PATH="/home/runner/.config/shorebird/bin:$PATH"
+
       - name: Choose Clock Face
         run: |
           # Choose a clock face based on the current hour

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Shorebird
-        uses: shorebirdtech/setup-shorebird@v1
+        uses: shorebirdtech/setup-shorebird@v1.1
 
       - name: Setup Shorebird Credentials
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -21,7 +21,7 @@ jobs:
 
       # TODO: move this to setup-shorebird once we've confirmed it works
       - name: Update PATH
-        run: echo "PATH=\"/home/runner/.config/shorebird/bin:$PATH\"" >> $"GITHUB_PATH"
+        run: echo "/home/runner/.config/shorebird/bin" >> $"GITHUB_PATH"
 
       - name: Choose Clock Face
         run: |
@@ -39,6 +39,6 @@ jobs:
 
       - name: Create Patch
         run: |
-          echo "Creating patch with ${{ env.clock_face }}"
+          echo "Creating patch with ${{ env.clock_face }} clock face"
           shorebird patch -- --dart-define clock_face=${{ env.clock_face }}
         

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Shorebird Credentials
         run: |
           echo "SHOREBIRD_CREDENTIALS_PATH is $SHOREBIRD_CREDENTIALS_PATH"
-          mkdir -p "$SHOREBIRD_CREDENTIALS_PATH'
+          mkdir -p "$SHOREBIRD_CREDENTIALS_PATH"
           echo "touching ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           touch "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo "touched ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -23,7 +23,9 @@ jobs:
           flutter-version: 3.7.8
 
       - name: Install Shorebird
-        run: curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | sh
+        run: |
+          curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | sh
+          export PATH=$HOME/.shorebird/bin:$PATH
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -23,9 +23,7 @@ jobs:
           flutter-version: 3.7.8
 
       - name: Install Shorebird
-        run: |
-          curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | sh
-          export PATH=$HOME/.shorebird/bin:$PATH
+        uses: time_shift/shorebird-action@v1
 
       - name: Choose Clock Face
         run: |
@@ -38,6 +36,7 @@ jobs:
           else
             clock_face=generative
           fi
+          echo "Using clock face $clock_face"
           echo "clock_face=$clock_face" >> $GITHUB_ENV
 
       - name: Create Patch

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -16,14 +16,8 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          flutter-version: 3.7.8
-
       - name: Install Shorebird
-        uses: time_shift/shorebird-action@v1
+        uses: shorebirdtech/setup-shorebird@v1
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -17,18 +17,18 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Git Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Shorebird
+        uses: shorebirdtech/setup-shorebird@70b705f05278f4af11ea6456d45b5a75d7e1c9a6
+
       - name: Setup Shorebird Credentials
         run: |
           mkdir -p "$SHOREBIRD_CREDENTIALS_PATH"
           echo "writing secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo "wrote secrets to json file"
-
-      - name: Git Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Shorebird
-        uses: shorebirdtech/setup-shorebird@70b705f05278f4af11ea6456d45b5a75d7e1c9a6
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Choose Clock Face
-      - run: |
+        run: |
           # Choose a clock face based on the current hour
           # Even hours = particle
           # Odd hours = generative
@@ -24,5 +24,5 @@ jobs:
           fi
 
       - name: Build Patch
-      - run: shorebird patch -- --dart-define clock_face=$clock_face
+        run: shorebird patch -- --dart-define clock_face=$clock_face
         

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -19,9 +19,10 @@ jobs:
       - name: Install Shorebird
         uses: shorebirdtech/setup-shorebird@v1
 
-      # TODO: move this to setup-shorebird once we've confirmed it works
-      - name: Update PATH
-        run: echo "/home/runner/.config/shorebird/bin" >> $GITHUB_PATH
+      - name: Setup Shorebird Credentials
+        run: |
+          mkdir -p $XDG_CONFIG_HOME/shorebird
+          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "$XDG_CONFIG_HOME/shorebird/shorebird-session.json"
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -27,8 +27,10 @@ jobs:
         run: |
           mkdir -p "$SHOREBIRD_CREDENTIALS_PATH"
           echo "writing secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
-          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
-          echo "wrote secrets to json file"
+          # echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
+          echo 'asdfasdf' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
+          cat "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
+          echo "wrote secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Note: this is specific to macOS
-  SHOREBIRD_CREDENTIALS_PATH: $HOME/Library/Application Support/shorebird
+  SHOREBIRD_CREDENTIALS_PATH: $HOME/Library/Application\ Support/shorebird
 
 jobs:
   publish_patch:
@@ -19,7 +19,6 @@ jobs:
     steps:
       - name: Setup Shorebird Credentials
         run: |
-          echo "HOME is $HOME"
           echo "SHOREBIRD_CREDENTIALS_PATH is $SHOREBIRD_CREDENTIALS_PATH"
           mkdir -p $SHOREBIRD_CREDENTIALS_PATH
           touch $SHOREBIRD_CREDENTIALS_PATH/shorebird-session.json

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -22,7 +22,6 @@ jobs:
 
       - name: Setup Shorebird Credentials
         run: |
-          echo ${{ steps.install-shorebird.outputs.INSTALL_PATH }} >> $GITHUB_PATH
           mkdir -p $XDG_CONFIG_HOME/shorebird
           echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "$XDG_CONFIG_HOME/shorebird/shorebird-session.json"
 

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Shorebird
-        uses: shorebirdtech/setup-shorebird@v1
+        uses: shorebirdtech/setup-shorebird@ed2912738a676459612aad64c63707b57b9dab64
 
       - name: Setup Shorebird Credentials
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -30,8 +30,11 @@ jobs:
         run: |
           mkdir -p "$SHOREBIRD_CREDENTIALS_PATH"
           echo "writing secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
-          echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
+          # echo '${{ secrets.SHOREBIRD_CREDENTIALS }}' > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
+          echo "{"api_key":"asdfadsfadsfads"}" > "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
           echo "wrote secrets to ${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
+          echo "secret contents:"
+          cat "${SHOREBIRD_CREDENTIALS_PATH}/shorebird-session.json"
 
       - name: Choose Clock Face
         run: |

--- a/.github/workflows/publish_patch.yaml
+++ b/.github/workflows/publish_patch.yaml
@@ -19,6 +19,9 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: Install Rosetta
+        run: softwareupdate --install-rosetta --agree-to-license
+
       - name: Git Checkout
         uses: actions/checkout@v3
 

--- a/shorebird-action.yaml
+++ b/shorebird-action.yaml
@@ -1,0 +1,7 @@
+name: 'Install Shorebird'
+description: 'Installs shorebird in the runner environment'
+runs:
+  using: "composite"
+  steps:
+    - id: shorebird-action
+      run: curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | sh

--- a/shorebird-action.yaml
+++ b/shorebird-action.yaml
@@ -1,7 +1,0 @@
-name: 'Install Shorebird'
-description: 'Installs shorebird in the runner environment'
-runs:
-  using: "composite"
-  steps:
-    - id: shorebird-action
-      run: curl --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/shorebirdtech/install/main/install.sh -sSf | sh


### PR DESCRIPTION
Fixes https://github.com/shorebirdtech/time_shift/issues/7

Creates a Github workflow that publishes a new version of the Time Shift app 15 minutes after the hour, every hour. Depending on whether the current hour is even or odd, the workflow will choose a different clock face.

NOTE: this is still very much a draft and is missing shorebird setup, signing, etc.