### PR TITLE
feat: add perf overlay option

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:time_shift/update_button.dart';
 
 import 'clocks/clock_face.dart';
 
@@ -10,6 +9,12 @@ import 'clocks/clock_face.dart';
 /// Example:
 /// `shorebird run -- --dart-define clock_face=generative`
 const clockFaceArgName = 'clock_face';
+
+/// Use this argument to show the performance overlay.
+///
+/// Example:
+/// `shorebird run -- --dart-define show_perf_overlay=true`
+const showPerfOverlayArgName = 'show_perf_overlay';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -23,6 +28,8 @@ void main() {
 
   runApp(
     MaterialApp(
+      showPerformanceOverlay:
+          const bool.fromEnvironment(showPerfOverlayArgName),
       debugShowCheckedModeBanner: false,
       home: Scaffold(
         body: clock.widget,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,13 +7,13 @@ import 'clocks/clock_face.dart';
 /// provided or if the value provided is unrecognized.
 ///
 /// Example:
-/// `shorebird run -- --dart-define clock_face=generative`
+/// `shorebird run -- --dart-define=clock_face=generative`
 const clockFaceArgName = 'clock_face';
 
 /// Use this argument to show the performance overlay.
 ///
 /// Example:
-/// `shorebird run -- --dart-define show_perf_overlay=true`
+/// `shorebird run -- --dart-define=show_perf_overlay=true`
 const showPerfOverlayArgName = 'show_perf_overlay';
 
 void main() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: time_shift
 description: Demo app showing Shorebird updates.
 publish_to: "none"
 
-version: 1.0.4+2
+version: 1.0.4+3
 
 environment:
   sdk: ">=2.19.4 <3.0.0"


### PR DESCRIPTION
Adds a dart-define option to show a performance overlay. See it using:

```
shorebird run -- --dart-define=show_perf_overlay=true
```