### PR TITLE
feat: updating shorebird code push package

### DIFF
--- a/lib/clocks/particle_clock/palette.dart
+++ b/lib/clocks/particle_clock/palette.dart
@@ -2,7 +2,6 @@ import 'dart:ui';
 
 /// Holds a list of colors.
 class Palette {
-
   /// The palette's color members. All unique.
   List<Color>? components;
 

--- a/lib/update_button.dart
+++ b/lib/update_button.dart
@@ -1,5 +1,3 @@
-import 'dart:ffi' as ffi;
-
 import 'package:flutter/material.dart';
 import 'package:restart_app/restart_app.dart';
 import 'package:shorebird_code_push/shorebird_code_push.dart';
@@ -19,26 +17,12 @@ enum UpdateStatus {
 
 class _UpdateButtonState extends State<UpdateButton> {
   UpdateStatus status = UpdateStatus.idle;
-  late bool _haveShorebirdEngine;
   bool _haveUpdate = false;
   final _shorebirdCodePush = ShorebirdCodePush();
 
-  @override
-  void initState() {
-    super.initState();
-    // TODO(eseidel): Remove after this is added to shorebird_code_push:
-    // https://github.com/shorebirdtech/updater/issues/49
-    final ffi.DynamicLibrary library = ffi.DynamicLibrary.process();
-    _haveShorebirdEngine = library.providesSymbol('shorebird_update');
-  }
-
-  Future<bool> _doUpdateCheck() async {
-    if (_haveShorebirdEngine) {
-      // Ask the Shorebird servers if there is a new patch available.
-      return _shorebirdCodePush.isNewPatchAvailableForDownload();
-    } else {
-      return Future.delayed(const Duration(seconds: 2), () => false);
-    }
+  Future<bool> _doUpdateCheck() {
+    // Ask the Shorebird servers if there is a new patch available.
+    return _shorebirdCodePush.isNewPatchAvailableForDownload();
   }
 
   Future<void> _checkForUpdate() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -164,10 +164,10 @@ packages:
     dependency: "direct main"
     description:
       name: shorebird_code_push
-      sha256: "6e82199a8f8b26422e570e214084717e9943919a05282bdbc9fa29573b2603a4"
+      sha256: "872839ac1e9b86f97db99c6456c4886620246f15e1cff9d29d4101e2beb991eb"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   restart_app: ^1.2.1
-  shorebird_code_push: ^1.0.0
+  shorebird_code_push: ^1.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updates the `shorebird_code_push` package in the app and remove old ffi hooking that is not needed anymore given the latest versions of the package.